### PR TITLE
Implement Rate Limiting for Bookmark Retrieval API-2

### DIFF
--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/annotation/RateLimited.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/annotation/RateLimited.java
@@ -1,0 +1,14 @@
+package com.bookmarkmanager.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimited {
+  long maxTokens() default 10; // Maximum tokens
+  long refillRate() default 1; // Tokens added per second
+  long refillInterval() default 1000;
+}

--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/bookmark/BookMarkController.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/bookmark/BookMarkController.java
@@ -1,11 +1,15 @@
 package com.bookmarkmanager.bookmark;
 
 
+import com.bookmarkmanager.annotation.RateLimited;
 import com.bookmarkmanager.pojo.Bookmark;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
 import java.util.UUID;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,7 +29,9 @@ public class BookMarkController {
   }
 
   @GetMapping("/{id}")
+  @RateLimited(maxTokens = 5, refillRate = 1, refillInterval = 1000)
   public ResponseEntity<Bookmark> getBookmarkById(@PathVariable UUID id) {
+    System.out.println("calling the method");
     Bookmark bookmark = bookmarkService.getBookmarkById(id);
     return ResponseEntity.ok(bookmark);
   }

--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/configuration/WebConfig.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/configuration/WebConfig.java
@@ -1,0 +1,19 @@
+package com.bookmarkmanager.configuration;
+
+import com.bookmarkmanager.ratelimiter.RateLimitInterceptor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  @Autowired
+  private RateLimitInterceptor rateLimitInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(rateLimitInterceptor);
+  }
+}

--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/exception/RateLimitException.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/exception/RateLimitException.java
@@ -1,0 +1,7 @@
+package com.bookmarkmanager.exception;
+
+public class RateLimitException extends RuntimeException{
+  public RateLimitException(String message) {
+    super(message);
+  }
+}

--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/ratelimiter/RateLimitInterceptor.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/ratelimiter/RateLimitInterceptor.java
@@ -1,0 +1,37 @@
+package com.bookmarkmanager.ratelimiter;
+
+import com.bookmarkmanager.annotation.RateLimited;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+@Component
+public class RateLimitInterceptor implements HandlerInterceptor {
+  private final ConcurrentHashMap<String, TokenBucket> buckets = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    if (handler instanceof HandlerMethod handlerMethod) {
+      RateLimited rateLimited = handlerMethod.getMethodAnnotation(RateLimited.class);
+      if (rateLimited != null) {
+        String clientIP = request.getRemoteAddr();
+        TokenBucket bucket = buckets.computeIfAbsent(clientIP, k -> new TokenBucket(rateLimited.maxTokens(), rateLimited.refillRate(), rateLimited.refillInterval()));
+        response.setHeader("X-RateLimit-Limit", String.valueOf(rateLimited.maxTokens()));
+        response.setHeader("X-RateLimit-Remaining", String.valueOf(bucket.getAvailableTokens())); // Assuming you have a method to get available tokens
+        response.setHeader("X-RateLimit-Reset", String.valueOf(bucket.getResetTime())); // Implement this method in TokenBucket
+        if (bucket.tryConsume(1)) {
+          return true; // Proceed with the request
+        } else {
+          response.setStatus(429); // Rate limit exceeded
+          return false;
+        }
+      }
+    }
+    return true; // Proceed if no rate limit
+  }
+}

--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/ratelimiter/TokenBucket.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/ratelimiter/TokenBucket.java
@@ -1,0 +1,47 @@
+package com.bookmarkmanager.ratelimiter;
+
+public class TokenBucket {
+  private long tokens;
+  private long lastRefillTime;
+  private final long maxTokens;
+  private final long refillRate;
+  private final long refillInterval;
+
+  public TokenBucket(long maxTokens, long refillRate, long refillInterval) {
+    this.maxTokens = maxTokens;
+    this.refillRate = refillRate;
+    this.refillInterval = refillInterval;
+    this.tokens = maxTokens;
+    this.lastRefillTime = System.currentTimeMillis();
+  }
+
+  public synchronized boolean tryConsume(int numTokens) {
+    refill();
+    if (tokens >= numTokens) {
+      tokens -= numTokens;
+      return true;
+    }
+    return false;
+  }
+
+  public synchronized long getAvailableTokens() {
+    refill(); // Ensure tokens are refilled before checking
+    return tokens;
+  }
+
+  public synchronized long getResetTime() {
+    long nextResetTime = lastRefillTime + refillInterval;
+    return Math.max(0, nextResetTime - System.currentTimeMillis());
+  }
+
+
+
+  private void refill() {
+    long now = System.currentTimeMillis();
+    long timeElapsed = now - lastRefillTime;
+
+    long tokensToAdd = (timeElapsed / refillInterval) * refillRate;
+    tokens = Math.min(maxTokens, tokens + tokensToAdd);
+    lastRefillTime = now;
+  }
+}

--- a/Bookmark-Manager/src/main/java/com/bookmarkmanager/ratelimiter/TokenBucket.java
+++ b/Bookmark-Manager/src/main/java/com/bookmarkmanager/ratelimiter/TokenBucket.java
@@ -25,7 +25,7 @@ public class TokenBucket {
   }
 
   public synchronized long getAvailableTokens() {
-    refill(); // Ensure tokens are refilled before checking
+    refill();
     return tokens;
   }
 


### PR DESCRIPTION
### **PR Description: Add Rate Limiting to `GET /bookmarks/{id}` Endpoint**

This PR introduces rate limiting for the `GET /bookmarks/{id}` API endpoint to control the flow of requests and prevent abuse. 

#### **New Feature:**
1. **Rate Limiting on `GET /bookmarks/{id}`:**
   - Added the `@RateLimited` annotation to enforce request limits for retrieving individual bookmarks by their `UUID`.
   - **Configuration:**
     - **Max Tokens**: 5 requests are allowed before the limit is reached.
     - **Refill Rate**: 1 token is added back every second.
     - **Refill Interval**: Tokens are refilled at a 1-second interval.